### PR TITLE
feat: add msgpack encoder and decoder

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.15
 
 require (
 	github.com/gogo/protobuf v1.3.2
+	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
 	go.mongodb.org/mongo-driver v1.5.1
 )

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,10 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=
+github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
+github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.0.2/go.mod h1:1WAq6h33pAW+iRreB34OORO2Nf7qel3VV3fjBj+hCSs=
 github.com/xdg-go/stringprep v1.0.2/go.mod h1:8F9zXuvzgwmyT5DUm4GUfZGDdT3W+LCvS6+da4O5kxM=

--- a/ptypes/struct.go
+++ b/ptypes/struct.go
@@ -40,7 +40,7 @@ type Struct struct {
 }
 
 func (s *Struct) EncodeMsgpack(encoder *msgpack.Encoder) error {
-	raw, err := s.MarshalJSONPB(defaultJSONPBMarshaler)
+	raw, err := proto.Marshal(s)
 	if err != nil {
 		return err
 	}
@@ -53,7 +53,8 @@ func (s *Struct) DecodeMsgpack(decoder *msgpack.Decoder) error {
 	if err != nil {
 		return err
 	}
-	return s.UnmarshalJSONPB(defaultJSONPBUnmarshaler, raw)
+
+	return proto.Unmarshal(raw, s)
 }
 
 func (s *Struct) GetFields() map[string]*types.Value {

--- a/ptypes/struct_test.go
+++ b/ptypes/struct_test.go
@@ -3,10 +3,12 @@ package ptypes
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/gogo/protobuf/types"
-	"go.mongodb.org/mongo-driver/bson"
 	"reflect"
 	"testing"
+
+	"github.com/gogo/protobuf/types"
+	"github.com/vmihailenco/msgpack/v5"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 func fixture() Struct {
@@ -120,5 +122,23 @@ func TestStruct_SQL(t *testing.T) {
 
 	if !reflect.DeepEqual(c, fixture()) {
 		t.Fatalf("result not match with fact, got %v", c)
+	}
+}
+
+func TestStruct_Msgpack(t *testing.T) {
+	f := fixture()
+	data, err := msgpack.Marshal(&f)
+	if err != nil {
+		t.Error(err)
+	}
+
+	c := Struct{}
+	err = msgpack.Unmarshal(data, &c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !reflect.DeepEqual(f, c) {
+		t.Fatalf("result does not match the fact, got %v", c)
 	}
 }


### PR DESCRIPTION
#### Desc

- add msgpack encoder and decoder to fix `reflect.Set: value of type map[string]interface {} is not assignable to type types.isValue_Kind` when using [vmihailenco/msgpack](https://github.com/vmihailenco/msgpack)